### PR TITLE
Disable some SwiftLint rules on Linux

### DIFF
--- a/Sources/InterposeKit/InterposeKit.swift
+++ b/Sources/InterposeKit/InterposeKit.swift
@@ -311,8 +311,11 @@ public struct IMP: Equatable {}
 public struct Method {}
 func NSSelectorFromString(_ aSelectorName: String) -> Selector { Selector() }
 func class_getInstanceMethod(_ cls: AnyClass?, _ name: Selector) -> Method? { return nil }
+// swiftlint:disable:next line_length
 func class_replaceMethod(_ cls: AnyClass?, _ name: Selector, _ imp: IMP, _ types: UnsafePointer<Int8>?) -> IMP? { IMP() }
+// swiftlint:disable:next identifier_name
 func method_getTypeEncoding(_ m: Method) -> UnsafePointer<Int8>? { return nil }
+// swiftlint:disable:next identifier_name
 func _dyld_register_func_for_add_image(_ func: (@convention(c) (UnsafePointer<Int8>?, Int) -> Void)!) {}
 func imp_implementationWithBlock(_ block: Any) -> IMP { IMP() }
 #endif


### PR DESCRIPTION
[See this](https://github.com/steipete/InterposeKit/actions/runs/121215237). It can be either disabled in this way or `// swiftlint:disable all` can be used.

Signed-off-by: Robert Vojta <rvojta@me.com>