### PR TITLE
Fixes code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ let interposer = try Interpose(TestClass.self) {
 
         print("After Interposing \(`self`)")
 
-        return string + testSwizzleAddition
+        return string + " and Interpose"
 
         // Similar signature cast as above, but without selector.
         } as @convention(block) (AnyObject) -> String})


### PR DESCRIPTION
`testSwizzleAddition` does not exist in the context of the example code.

Instead of creating `testSwizzleAddition` I decided to inline the value as I feel this makes matching the output with the example code easier 😄 