### PR TITLE
Cleanup hook blocks

### DIFF
--- a/Sources/InterposeKit/InterposeKit.swift
+++ b/Sources/InterposeKit/InterposeKit.swift
@@ -150,6 +150,7 @@ extension Interpose {
             try execute(newState: .prepared) { try resetImplementation() }
         }
 
+        /// Release the hook block if possible.
         public func cleanup() {
             switch state {
             case .prepared:

--- a/Sources/InterposeKit/InterposeKit.swift
+++ b/Sources/InterposeKit/InterposeKit.swift
@@ -340,4 +340,5 @@ func method_getTypeEncoding(_ m: Method) -> UnsafePointer<Int8>? { return nil }
 // swiftlint:disable:next identifier_name
 func _dyld_register_func_for_add_image(_ func: (@convention(c) (UnsafePointer<Int8>?, Int) -> Void)!) {}
 func imp_implementationWithBlock(_ block: Any) -> IMP { IMP() }
+func imp_removeBlock(_ anImp: IMP) -> Bool { false }
 #endif


### PR DESCRIPTION
Looks like `imp_removeBlock` can be used to release the `IMP` block.

Currently, `IMP` and `Task` form a retain cycle, which I break in `Interpose.deinit`. But this may be an issue if the client code keeps the `Task` instance and attempts to apply it after the interposer is released.