### PR TITLE
Fix first example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ class TestClass: NSObject {
 }
 
 let interposer = try Interpose(TestClass.self) {
-    try $0.hook(
+    try $0.prepareHook(
         #selector(TestClass.sayHi),
         methodSignature: (@convention(c) (AnyObject, Selector) -> String).self,
         hookSignature: (@convention(block) (AnyObject) -> String).self) {


### PR DESCRIPTION
Calling `hook` leads to an error where the state is expected to be prepared because the `Interpose(…builder:)` initializer used here automatically applies hooks, so `prepareHook` is fine.