### PR TITLE
Fix crash due to IKTAddSuperImplementationToClass being stripped

### DIFF
--- a/Sources/SuperBuilder/src/ITKSuperBuilder.m
+++ b/Sources/SuperBuilder/src/ITKSuperBuilder.m
@@ -36,13 +36,6 @@ static IMP ITKGetTrampolineForTypeEncoding(__unused const char *typeEncoding) {
     return requiresStructDispatch ? (IMP)msgSendSuperStretTrampoline : (IMP)msgSendSuperTrampoline;
 }
 
-// Helper for binding with Swift
-__attribute__((__used__))
-BOOL IKTAddSuperImplementationToClass(Class originalClass, SEL selector, NSError **error);
-BOOL IKTAddSuperImplementationToClass(Class originalClass, SEL selector, NSError **error) {
-    return [SuperBuilder addSuperInstanceMethodToClass:originalClass selector:selector error:error];
-}
-
 #define ERROR_AND_RETURN(CODE, STRING)\
 if (error) { *error = [NSError errorWithDomain:SuperBuilderErrorDomain code:CODE userInfo:@{NSLocalizedDescriptionKey: STRING}];} return NO;
 

--- a/Sources/SuperBuilder/src/ITKSuperBuilder.m
+++ b/Sources/SuperBuilder/src/ITKSuperBuilder.m
@@ -37,6 +37,7 @@ static IMP ITKGetTrampolineForTypeEncoding(__unused const char *typeEncoding) {
 }
 
 // Helper for binding with Swift
+__attribute__((__used__))
 BOOL IKTAddSuperImplementationToClass(Class originalClass, SEL selector, NSError **error);
 BOOL IKTAddSuperImplementationToClass(Class originalClass, SEL selector, NSError **error) {
     return [SuperBuilder addSuperInstanceMethodToClass:originalClass selector:selector error:error];


### PR DESCRIPTION
This fixes https://github.com/steipete/InterposeKit/issues/29 for me. I think without the `used` attribute, the compiler optimizes the function away as it appears to be unused.