### PR TITLE
restore floating point registers from stack in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Preserve trampoline argument registers in code-coverage builds.
 * Preserve object-hook super trampolines in optimized Release builds, fixing https://github.com/steipete/InterposeKit/issues/29. Thanks to [@Thomvis](https://github.com/Thomvis).
+* Preserve floating-point arguments when object hooks invoke original methods on arm64. Thanks to [@ishutinvv](https://github.com/ishutinvv).
 
 ## 0.01
 

--- a/Sources/SuperBuilder/src/ITKSuperBuilder.m
+++ b/Sources/SuperBuilder/src/ITKSuperBuilder.m
@@ -213,10 +213,10 @@ void msgSendSuperTrampoline(void) {
 
 #if PROTECT_FLOATING_POINT_REGISTERS
                   // pop {q0-q7}
-                  "ldp q6, q7, [sp], #32\n"
-                  "ldp q4, q5, [sp], #32\n"
-                  "ldp q2, q3, [sp], #32\n"
                   "ldp q0, q1, [sp], #32\n"
+                  "ldp q2, q3, [sp], #32\n"
+                  "ldp q4, q5, [sp], #32\n"
+                  "ldp q6, q7, [sp], #32\n"
 #endif
 
                   // get new return (adr of the objc_super class)

--- a/Tests/InterposeKitTests/ObjectInterposeTests.swift
+++ b/Tests/InterposeKitTests/ObjectInterposeTests.swift
@@ -134,6 +134,26 @@ final class ObjectInterposeTests: InterposeKitTestCase {
         try hook.revert()
     }
 
+    #if arch(arm64)
+        func test8FloatingPointParameters() throws {
+            let testObj = TestClass()
+            let expected = 87_654_321.0
+            XCTAssertEqual(testObj.combine(1, 2, 3, 4, 5, 6, 7, 8), expected)
+
+            let hook = try testObj.hook(#selector(TestClass.combine)) { (store: TypedHook
+                <@convention(c) (AnyObject, Selector, Double, Double, Double, Double,
+                                 Double, Double, Double, Double) -> Double,
+                @convention(block) (AnyObject, Double, Double, Double, Double,
+                                    Double, Double, Double, Double) -> Double>) in {
+                    store.original($0, store.selector, $1, $2, $3, $4, $5, $6, $7, $8)
+                }
+            }
+
+            XCTAssertEqual(testObj.combine(1, 2, 3, 4, 5, 6, 7, 8), expected)
+            try hook.revert()
+        }
+    #endif
+
     func testObjectCallReturn() throws {
         let testObj = TestClass()
         let str = "foo"

--- a/Tests/InterposeKitTests/TestClass.swift
+++ b/Tests/InterposeKitTests/TestClass.swift
@@ -53,6 +53,15 @@ class TestClass: NSObject {
         var1 + var2 + var3 + var4 + var5 + var6
     }
 
+    #if arch(arm64)
+        // swiftlint:disable:next function_parameter_count
+        @objc dynamic func combine(_ value0: Double, _ value1: Double, _ value2: Double, _ value3: Double,
+                                   _ value4: Double, _ value5: Double, _ value6: Double, _ value7: Double) -> Double {
+            value0 + (value1 * 10) + (value2 * 100) + (value3 * 1_000)
+                + (value4 * 10_000) + (value5 * 100_000) + (value6 * 1_000_000) + (value7 * 10_000_000)
+        }
+    #endif
+
     // This requires _objc_msgSendSuper_stret on x64, returns a large struct
     @objc dynamic func invert3DTransform(_ input: CATransform3D) -> CATransform3D {
         input.inverted


### PR DESCRIPTION
We should restore registers preserved in stack in reverse order. Otherwise, it leads to shuffled values in those registers after trampoline.

The simplest way to reproduce is to swizzle any method from UIKit that accepts CGFloat or plain struct like CGRect. It's relevant only to arm64.
Btw, regular registers get restored correctly.