### PR TITLE
Fix coverage-instrumented trampolines

### DIFF
--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -34,19 +34,21 @@ jobs:
       - run: xcodebuild -version
       - name: macOS with UTF16
         if: always()
-        run: YAMS_DEFAULT_ENCODING=UTF16 xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} test | xcpretty
+        run: YAMS_DEFAULT_ENCODING=UTF16 xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} -destination "platform=macOS,arch=$(uname -m)" test | xcpretty
         shell: bash
       - name: macOS with UTF8
         if: always()
-        run: YAMS_DEFAULT_ENCODING=UTF8 xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} test | xcpretty
+        run: YAMS_DEFAULT_ENCODING=UTF8 xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} -destination "platform=macOS,arch=$(uname -m)" test | xcpretty
         shell: bash
       - name: iPhone Simulator
         if: always()
-        run: xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} test -sdk iphonesimulator -destination "name=iPhone 15" | xcpretty
+        run: |
+          destination_id="$(xcrun simctl list devices available -j | jq -er '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid')"
+          xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} test -sdk iphonesimulator -destination "platform=iOS Simulator,id=$destination_id" | xcpretty
         shell: bash
       - name: Apple TV Simulator
         if: always()
-        run: xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} test -sdk appletvsimulator -destination "name=Apple TV 4K" | xcpretty
+        run: xcodebuild ${{ matrix.xcode_flags }} ${{ matrix.flags_for_test }} test -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV" | xcpretty
         shell: bash
       - name: watchOS Simulator
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ##### Bug Fixes
 
-* None.
+* Preserve trampoline argument registers in code-coverage builds.
 
 ## 0.01
 

--- a/Sources/SuperBuilder/src/ITKSuperBuilder.m
+++ b/Sources/SuperBuilder/src/ITKSuperBuilder.m
@@ -168,9 +168,15 @@ struct objc_super *ITKReturnThreadSuper(__unsafe_unretained id obj, SEL _cmd) {
  https://azeria-labs.com/functions-and-the-stack-part-7/
  */
 
+#if __has_attribute(no_profile_instrument_function)
+#define ITK_NAKED_TRAMPOLINE __attribute__((__naked__, no_profile_instrument_function))
+#else
+#define ITK_NAKED_TRAMPOLINE __attribute__((__naked__))
+#endif
+
 #if defined(__arm64__)
 
-__attribute__((__naked__))
+ITK_NAKED_TRAMPOLINE
 void msgSendSuperTrampoline(void) {
     asm volatile (
 
@@ -224,7 +230,7 @@ void msgSendSuperStretTrampoline(void) {}
 
 #elif defined(__x86_64__)
 
-__attribute__((__naked__))
+ITK_NAKED_TRAMPOLINE
 void msgSendSuperTrampoline(void) {
     asm volatile (
                   //  push frame pointer
@@ -292,7 +298,7 @@ void msgSendSuperTrampoline(void) {
 }
 
 
-__attribute__((__naked__))
+ITK_NAKED_TRAMPOLINE
 void msgSendSuperStretTrampoline(void) {
     asm volatile (
                   //  push frame pointer


### PR DESCRIPTION
## Summary

- prevent coverage instrumentation from clobbering argument registers before naked trampoline assembly runs
- make macOS and simulator destinations explicit/current on hosted runners
- keep the existing large-struct regression test active under code coverage

This unblocks the Xcode checks needed by https://github.com/steipete/InterposeKit/pull/42.

## Proof

- `swift test`
- `swift test -c release`
- full macOS arm64 and x86_64 Xcode test suites with code coverage
- full iOS simulator Xcode test suite with code coverage
- watchOS simulator build
- arm64 disassembly starts with trampoline register saves; no profiling prologue
- `$autoreview`: clean

Local tvOS execution was unavailable because the installed Xcode lacks the tvOS platform component. The destination now uses the current `Apple TV` device name and is covered by hosted CI.
